### PR TITLE
스프링데이터 Jpa

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+ext["hibernate.version"] = "5.6.5.Final"
+
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor

--- a/src/main/java/hello/itemservice/ItemServiceApplication.java
+++ b/src/main/java/hello/itemservice/ItemServiceApplication.java
@@ -18,9 +18,10 @@ import javax.sql.DataSource;
 //@Import(JdbcTemplateV2Config.class)
 //@Import(JdbcTemplateV3Config.class)
 //@Import(MyBatisConfig.class)
+//@Import(JpaConfig.class)
 
 @Slf4j
-@Import(JpaConfig.class)
+@Import(SpringDataJpaConfig.class)
 @SpringBootApplication(scanBasePackages = "hello.itemservice.web")
 public class ItemServiceApplication {
 

--- a/src/main/java/hello/itemservice/config/SpringDataJpaConfig.java
+++ b/src/main/java/hello/itemservice/config/SpringDataJpaConfig.java
@@ -1,0 +1,30 @@
+package hello.itemservice.config;
+
+import hello.itemservice.repository.ItemRepository;
+import hello.itemservice.repository.jpa.JpaItemRepository;
+import hello.itemservice.repository.jpa.JpaItemRepositoryV2;
+import hello.itemservice.repository.jpa.SpringDataJpaItemRepository;
+import hello.itemservice.service.ItemService;
+import hello.itemservice.service.ItemServiceV1;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class SpringDataJpaConfig {
+
+    private final SpringDataJpaItemRepository repository;
+
+    @Bean
+    public ItemService itemService(){
+        return new ItemServiceV1(itemRepository());
+    }
+
+    @Bean
+    public ItemRepository itemRepository(){
+        return new JpaItemRepositoryV2(repository);
+    }
+}

--- a/src/main/java/hello/itemservice/repository/jpa/JpaItemRepositoryV2.java
+++ b/src/main/java/hello/itemservice/repository/jpa/JpaItemRepositoryV2.java
@@ -1,0 +1,59 @@
+package hello.itemservice.repository.jpa;
+
+import hello.itemservice.domain.Item;
+import hello.itemservice.repository.ItemRepository;
+import hello.itemservice.repository.ItemSearchCond;
+import hello.itemservice.repository.ItemUpdateDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class JpaItemRepositoryV2 implements ItemRepository {
+
+    private final SpringDataJpaItemRepository repository;
+
+    @Override
+    public Item save(Item item) {
+        return repository.save(item);
+    }
+
+    @Override
+    public void update(Long itemId, ItemUpdateDto updateParam) {
+        Item findItem = repository.findById(itemId).orElseThrow();
+        findItem.setItemName(updateParam.getItemName());
+        findItem.setPrice(updateParam.getPrice());
+        findItem.setQuantity(updateParam.getQuantity());
+
+    }
+
+    @Override
+    public Optional<Item> findById(Long id) {
+        return repository.findById(id);
+    }
+
+    @Override
+    public List<Item> findAll(ItemSearchCond cond) {
+        String itemName = cond.getItemName();
+        Integer maxPrice = cond.getMaxPrice();
+
+        if(StringUtils.hasText(itemName) && maxPrice != null){
+//            return repository.findByItemNameLikeAndPriceLessThanEqual("%"+itemName+"%",maxPrice);
+            return repository.findItems("%"+itemName+"%",maxPrice);
+        } else if (StringUtils.hasText(itemName)) {
+            return repository.findByItemNameLike("%"+itemName+"%");
+        } else if (maxPrice != null) {
+            return repository.findByPriceLessThanEqual(maxPrice);
+        } else {
+            return repository.findAll();
+        }
+
+    }
+}


### PR DESCRIPTION
SpringDataJapItemRepository 에서
ItemRepository interface 를 구현하지 않고
JpaRepository 를 상속 받았기 때문에
바로 사용 할 수 없다.
JpaItemRepositoryV2 버전을 생성하여
SpringDataJpaItemRepository 를 주입 받아
ItemRepository 구현체를 만들어 기존 코드 변경 없이 사용한다.