### PR TITLE
실용적인 구조

### DIFF
--- a/src/main/java/hello/itemservice/ItemServiceApplication.java
+++ b/src/main/java/hello/itemservice/ItemServiceApplication.java
@@ -20,9 +20,10 @@ import javax.sql.DataSource;
 //@Import(MyBatisConfig.class)
 //@Import(JpaConfig.class)
 //@Import(SpringDataJpaConfig.class)
+//@Import(QuerydslConfig.class)
 
 @Slf4j
-@Import(QuerydslConfig.class)
+@Import(V2Config.class)
 @SpringBootApplication(scanBasePackages = "hello.itemservice.web")
 public class ItemServiceApplication {
 

--- a/src/main/java/hello/itemservice/config/V2Config.java
+++ b/src/main/java/hello/itemservice/config/V2Config.java
@@ -1,0 +1,36 @@
+package hello.itemservice.config;
+
+import hello.itemservice.repository.ItemRepository;
+import hello.itemservice.repository.jpa.JpaItemRepositoryV3;
+import hello.itemservice.repository.v2.ItemQueryRepositoryV2;
+import hello.itemservice.repository.v2.ItemRepositoryV2;
+import hello.itemservice.service.ItemService;
+import hello.itemservice.service.ItemServiceV2;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class V2Config {
+
+    private final EntityManager em;
+    private final ItemRepositoryV2 itemRepositoryV2; // SpringDataJPA
+
+    @Bean
+    public ItemService itemService(){
+        return new ItemServiceV2(itemRepositoryV2, itemQueryRepositoryV2());
+    }
+
+    @Bean
+    public ItemQueryRepositoryV2 itemQueryRepositoryV2(){
+        return new ItemQueryRepositoryV2(em);
+    }
+
+    @Bean
+    public ItemRepository itemRepository(){
+        return new JpaItemRepositoryV3(em);
+    }
+}

--- a/src/main/java/hello/itemservice/repository/v2/ItemQueryRepositoryV2.java
+++ b/src/main/java/hello/itemservice/repository/v2/ItemQueryRepositoryV2.java
@@ -1,0 +1,49 @@
+package hello.itemservice.repository.v2;
+
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import hello.itemservice.domain.Item;
+import hello.itemservice.domain.QItem;
+import hello.itemservice.repository.ItemSearchCond;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static hello.itemservice.domain.QItem.item;
+
+@Repository
+public class ItemQueryRepositoryV2 {
+
+    private final JPAQueryFactory query;
+
+    public ItemQueryRepositoryV2(EntityManager em) {
+        this.query = new JPAQueryFactory(em);
+    }
+
+    public List<Item> findAll(ItemSearchCond cond){
+        return query.select(item)
+                .from(item)
+                .where(
+                        likeItemName(cond.getItemName()),
+                        maxPrice(cond.getMaxPrice())
+                )
+                .fetch();
+    }
+
+    private BooleanExpression maxPrice(Integer maxPrice) {
+        if(maxPrice != null){
+            return item.price.loe(maxPrice);
+        }
+        return null;
+    }
+
+    private BooleanExpression likeItemName(String itemName) {
+        if(StringUtils.hasText(itemName)){
+            return item.itemName.like("%"+itemName+"%");
+        }
+        return null;
+    }
+}

--- a/src/main/java/hello/itemservice/repository/v2/ItemRepositoryV2.java
+++ b/src/main/java/hello/itemservice/repository/v2/ItemRepositoryV2.java
@@ -1,0 +1,7 @@
+package hello.itemservice.repository.v2;
+
+import hello.itemservice.domain.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepositoryV2 extends JpaRepository<Item, Long> {
+}

--- a/src/main/java/hello/itemservice/service/ItemServiceV2.java
+++ b/src/main/java/hello/itemservice/service/ItemServiceV2.java
@@ -1,0 +1,44 @@
+package hello.itemservice.service;
+
+import hello.itemservice.domain.Item;
+import hello.itemservice.repository.ItemSearchCond;
+import hello.itemservice.repository.ItemUpdateDto;
+import hello.itemservice.repository.v2.ItemQueryRepositoryV2;
+import hello.itemservice.repository.v2.ItemRepositoryV2;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ItemServiceV2 implements ItemService{
+    private final ItemRepositoryV2 itemRepositoryV2;
+    private final ItemQueryRepositoryV2 queryRepositoryV2;
+
+    @Override
+    public Item save(Item item) {
+        return itemRepositoryV2.save(item);
+    }
+
+    @Override
+    public void update(Long itemId, ItemUpdateDto updateParam) {
+        Item findItem = itemRepositoryV2.findById(itemId).orElseThrow();
+        findItem.setItemName(updateParam.getItemName());
+        findItem.setPrice(updateParam.getPrice());
+        findItem.setQuantity(updateParam.getQuantity());
+    }
+
+    @Override
+    public Optional<Item> findById(Long id) {
+        return itemRepositoryV2.findById(id);
+    }
+
+    @Override
+    public List<Item> findItems(ItemSearchCond cond) {
+        return queryRepositoryV2.findAll(cond);
+    }
+}


### PR DESCRIPTION
ItemServiceV2 에서 ItemRepositoryV2 와
ItemQueryRepositoryV2 를 바로 참조 하게 변경함
ItemRepositoryV2 는 JpaRepository를 상속 받아 사용하여
빈에 자동으로 등록 됨